### PR TITLE
Fix build props path

### DIFF
--- a/build/name.atsushieno.proguard.facebook.props
+++ b/build/name.atsushieno.proguard.facebook.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AndroidSkipJavacVersionCheck>True</AndroidSkipJavacVersionCheck>
-    <ProguardToolPath>$(MSBuildThisFileDirectory)..</ProguardToolPath>
+    <ProguardToolPath>$(MSBuildThisFileDirectory)../</ProguardToolPath>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Using `$(MSBuildThisFileDirectory)..` resolves to

```
/packages/name.atsushieno.proguard.facebook.5.3.2.2/build/name.atsushieno.proguard.facebook.props..lib/proguard.jar
```

Which obviously gives an error of `proguard.jar` not found.

Fixing this so it resolves correctly.

This happened to me on my mac using Visual Studio for Mac, not sure if it happened on Windows too, it probably did.
  